### PR TITLE
Remove cmd line arg parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ Can handle files as large as the underlying OS/Hardware can handle by using 4K b
 
 ### Some extension
 
-- Add command line parsing with Decline (https://github.com/bkirwi/decline)
-~~Add weaver tests when weaver test moves to 3.0 (https://github.com/disneystreaming/weaver-test)~~
-- Add "plugable" encryption libraries.
-- Add binary encryption 
+- [x] Add weaver tests when weaver test moves for 3.0 
+- [ ] Add "plugable" encryption pipeline stages.
+- [ ] Add binary encryption 
 
 
 

--- a/src/main/scala/global/vigil/streamcrypt/StreamCrypt.scala
+++ b/src/main/scala/global/vigil/streamcrypt/StreamCrypt.scala
@@ -7,7 +7,7 @@ import fs2.{Stream, text}
 
 import java.nio.file.Paths
 
-// TODO - make this a "full" IO app an parse incoming args with decline
+
 object StreamCrypt extends IOApp.Simple {
 
   val blockSize = 1024 * 4


### PR DESCRIPTION
Decline is not quite ready for 3.0 so removed requirement for the time being 